### PR TITLE
Quality of life change

### DIFF
--- a/lacam3/src/graph.cpp
+++ b/lacam3/src/graph.cpp
@@ -30,7 +30,7 @@ Graph::Graph(const std::vector<std::vector<int>> &map) : V(Vertices()), width(0)
   for (int x = 0; x < height; ++x) {
     for (int y = 0; y < width; ++y) {
       // printf("x: %d, y: %d\n", x, y);
-      if (map[x][y] == 1) continue;  // obstacle
+      if (map[x][y] != 0) continue;  // obstacle
       auto index = width * x + y;
       // printf("index: %d\n", index);
       auto v = new Vertex(V.size(), index, x, y);


### PR DESCRIPTION
Extending support to [0 , "non 0"] map instead of [0,1] maps

In file graph.cpp:

if (map[x][y] ==1) continue;  //obstacle
changed to
if (map[x][y] != 0) continue; //obstacle