### PR TITLE
Don't use N as number of threads when constructing dist_table

### DIFF
--- a/lacam3/include/utils.hpp
+++ b/lacam3/include/utils.hpp
@@ -20,6 +20,7 @@
 #include <set>
 #include <stack>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 

--- a/lacam3/src/dist_table.cpp
+++ b/lacam3/src/dist_table.cpp
@@ -31,9 +31,14 @@ void DistTable::setup(const Instance *ins)
     }
   };
 
+  const int num_threads =
+      std::max(1u, std::min((unsigned)ins->N,
+                            std::thread::hardware_concurrency()));
   auto pool = std::vector<std::future<void>>();
-  for (size_t i = 0; i < ins->N; ++i) {
-    pool.emplace_back(std::async(std::launch::async, bfs, i));
+  for (int t = 0; t < num_threads; ++t) {
+    pool.emplace_back(std::async(std::launch::async, [&, t]() {
+      for (int i = t; i < (int)ins->N; i += num_threads) bfs(i);
+    }));
   }
 }
 


### PR DESCRIPTION
Bug: when running an instance with 2000 agents, dist_table is using 2000 threads at once.
On a regular laptop, it crashes immediately with a message:
std::system_error'
what(): Resource temporarily unavailable.

Fix: use the amount of threads allowed by the system.