### PR TITLE
fix: disable multithreading in DistTable when no-multi-thread flag is set

### DIFF
--- a/lacam3/include/dist_table.hpp
+++ b/lacam3/include/dist_table.hpp
@@ -8,6 +8,7 @@
 #include "utils.hpp"
 
 struct DistTable {
+  static bool FLG_MULTI_THREAD;  // whether to use multi-threading
   const int K;  // number of vertices
   std::vector<std::vector<int>>
       table;  // distance table, index: agent-id & vertex-id

--- a/lacam3/src/dist_table.cpp
+++ b/lacam3/src/dist_table.cpp
@@ -1,5 +1,7 @@
 #include "../include/dist_table.hpp"
 
+bool DistTable::FLG_MULTI_THREAD = true;
+
 DistTable::DistTable(const Instance &ins)
     : K(ins.G->V.size()), table(ins.N, std::vector<int>(K, K))
 {
@@ -31,14 +33,18 @@ void DistTable::setup(const Instance *ins)
     }
   };
 
-  const int num_threads =
-      std::max(1u, std::min((unsigned)ins->N,
-                            std::thread::hardware_concurrency()));
-  auto pool = std::vector<std::future<void>>();
-  for (int t = 0; t < num_threads; ++t) {
-    pool.emplace_back(std::async(std::launch::async, [&, t]() {
-      for (int i = t; i < (int)ins->N; i += num_threads) bfs(i);
-    }));
+  if (FLG_MULTI_THREAD) {
+	const int num_threads =
+		std::max(1u, std::min((unsigned)ins->N,
+								std::thread::hardware_concurrency()));
+	auto pool = std::vector<std::future<void>>();
+	for (int t = 0; t < num_threads; ++t) {
+		pool.emplace_back(std::async(std::launch::async, [&, t]() {
+		for (int i = t; i < (int)ins->N; i += num_threads) bfs(i);
+		}));
+	}
+  } else {
+    for (int i = 0; i < (int)ins->N; ++i) bfs(i);
   }
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -131,6 +131,7 @@ int main(int argc, char *argv[])
           : std::stof(program.get<std::string>("recursive-time-limit")) * 1000;
   Planner::CHECKPOINTS_DURATION =
       std::stof(program.get<std::string>("checkpoints-duration")) * 1000;
+  DistTable::FLG_MULTI_THREAD = Planner::FLG_MULTI_THREAD;
 
   // solve
   const auto deadline = Deadline(time_limit_sec * 1000);


### PR DESCRIPTION
Fix `DistTable` to obey `--no-multi-thread`.

The distance table initialization was still using async BFS even when the option was enabled. This patch connects the flag to `DistTable` and disables threaded setup in single-thread mode.